### PR TITLE
Add textobject queries for 'xml' filetype

### DIFF
--- a/after/queries/xml/textobjects.scm
+++ b/after/queries/xml/textobjects.scm
@@ -1,0 +1,1 @@
+(element (content) @function.inner) @function.outer


### PR DESCRIPTION
Turns out, 'nvim-treesitter-textobjects' [don't have queries for 'xml' filetype](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/tree/master/queries). This PR creates necessary queries locally. It might be a good idea to push updated version of this upstream. Take a look at what queries should be covered based on [html filetype](https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/master/queries/html/textobjects.scm) and make use of `:InspectTree` (starting from Neovim 0.9.0).